### PR TITLE
Update 2.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Passwords is an innovative and user-friendly plugin designed to enhance the secu
 - **Adjustable Password Lengths**  
   Customize the password length to achieve the desired balance between security and convenience.
 
-
 - **Seamless Integration**  
   Works effortlessly with any Minecraft server without requiring complex setup procedures.
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,6 @@ implementation files("$projectDir/lib/passwords-VERSION.jar")
 
 ## License
 
-Passwords is licensed under the MIT License, allowing for free use, modification, and distribution. For more details, see the [LICENSE](https://github.com/HamburgBigJ/Passwords/blob/main/LICENSE) file in the repository.
+Passwords is licensed under the MIT License, allowing for free use, modification, and distribution. For more details, see the [LICENSE](https://github.com/HamburgBigJ/Passwords/blob/main/LICENSE.txt) file in the repository.
 
 Enhance your Minecraft server's security and provide a personalized experience for your players with Passwords! 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'info.cho'
-version = '2.5'
+version = '2.6'
 
 repositories {
     mavenCentral()
@@ -17,6 +17,11 @@ repositories {
         name = "sonatype"
         url = "https://oss.sonatype.org/content/groups/public/"
     }
+
+    maven {
+        url = 'https://repo.extendedclip.com/releases/'
+    }
+
     maven{url "https://repo.codemc.org/repository/maven-public/"}
 
     maven { url 'https://nexus.scarsz.me/content/groups/public/' }
@@ -27,7 +32,9 @@ dependencies {
 
     implementation("dev.jorel:commandapi-bukkit-shade:10.1.2")
 
+    // Extern Apis
     compileOnly("com.discordsrv:discordsrv:1.30.0")
+    compileOnly ("me.clip:placeholderapi:2.11.6")
 }
 
 tasks {
@@ -36,7 +43,10 @@ tasks {
     }
 
     runServer {
-        minecraftVersion("1.21.5")
+        downloadPlugins {
+            url("https://www.spigotmc.org/resources/placeholderapi.6245/download?version=541946")
+        }
+        minecraftVersion("1.21.8")
     }
 
     build {

--- a/src/main/java/info/cho/passwords/Passwords.java
+++ b/src/main/java/info/cho/passwords/Passwords.java
@@ -9,9 +9,12 @@ import info.cho.passwords.customGui.CustomGui;
 import info.cho.passwords.customGui.CustomGuiHandler;
 import info.cho.passwords.hook.DiscordHook;
 import info.cho.passwords.player.PasswordPlayerMode;
+import info.cho.passwords.server.PasswordNoneMode;
+import info.cho.passwords.server.PasswordPatternMode;
 import info.cho.passwords.server.PasswordServerMode;
 import info.cho.passwords.utls.PLog;
 import info.cho.passwordsApi.password.PasswordConfig;
+import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.Objects;
@@ -20,7 +23,7 @@ public class Passwords extends JavaPlugin {
 
     public static Passwords instance;
     public static CustomGui customGui;
-    public static String version = "2.5";
+    public static String version = "2.6";
 
     @Override
     public void onLoad() {
@@ -36,6 +39,13 @@ public class Passwords extends JavaPlugin {
         CommandAPI.onEnable();
         CustomGuiHandler customGuiHandler = new CustomGuiHandler(customGui);
 
+        if (Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
+            PLog.info("Found PlaceholderAPI! Registering placeholders...");
+        } else {
+            PLog.warning("Could not find PlaceholderAPI! This plugin is required.");
+            Bukkit.getPluginManager().disablePlugin(this);
+            return;
+        }
 
         if (PasswordConfig.isUseDiscordLogin()) {
             DiscordHook discordHook = new DiscordHook();
@@ -56,8 +66,11 @@ public class Passwords extends JavaPlugin {
         SetPlayerPasswordCommand setPlayerPasswordCommand = new SetPlayerPasswordCommand();
         SetPasswordCommand setPasswordCommand = new SetPasswordCommand();
 
+        // PasswordGui registration
         customGui.registerGui("server", PasswordServerMode.class);
         customGui.registerGui("player", PasswordPlayerMode.class);
+        customGui.registerGui("none", PasswordNoneMode.class);
+        customGui.registerGui("pattern", PasswordPatternMode.class);
 
 
     }
@@ -79,12 +92,13 @@ public class Passwords extends JavaPlugin {
         } else {
             PLog.info("Your version is up to date!");
 
-            PLog.debug("!!!!!!!!-----------------------------------------------------------------------------------!!!!!!!!");
+            PLog.debug("!!!!!!!!------------------------ This is not an Error -------------------------------------!!!!!!!!");
             PLog.debug("Your version: " + version);
             PLog.debug("Config version: " + PasswordConfig.getVersion());
             PLog.debug("!!!!!!!!-----------------------------------------------------------------------------------!!!!!!!!");
 
         }
     }
+
 
 }

--- a/src/main/java/info/cho/passwords/Passwords.java
+++ b/src/main/java/info/cho/passwords/Passwords.java
@@ -12,11 +12,18 @@ import info.cho.passwords.player.PasswordPlayerMode;
 import info.cho.passwords.server.PasswordNoneMode;
 import info.cho.passwords.server.PasswordPatternMode;
 import info.cho.passwords.server.PasswordServerMode;
+import info.cho.passwords.utls.DataManager;
 import info.cho.passwords.utls.PLog;
 import info.cho.passwordsApi.password.PasswordConfig;
 import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 public class Passwords extends JavaPlugin {
@@ -72,6 +79,9 @@ public class Passwords extends JavaPlugin {
         customGui.registerGui("none", PasswordNoneMode.class);
         customGui.registerGui("pattern", PasswordPatternMode.class);
 
+        if (PasswordConfig.useAutoSave()) {
+            savePlayerInventory();
+        }
 
     }
 
@@ -86,6 +96,7 @@ public class Passwords extends JavaPlugin {
         if(!Objects.equals(version, getConfig().getString("version"))) {
             PLog.warning("!!!!!!!!-----------------------------------------------------------------------------------!!!!!!!!");
             PLog.warning("Your version is outdated! Please delete the config.yml and restart the server to get the latest version!");
+            PLog.warning("DO NOT DELETE THE Data FOLDER OR ALL INVENTORIES WILL BE LOST!");
             PLog.warning("Your version: " + version);
             PLog.warning("Config version: " + PasswordConfig.getVersion());
             PLog.warning("!!!!!!!!-----------------------------------------------------------------------------------!!!!!!!!");
@@ -98,6 +109,43 @@ public class Passwords extends JavaPlugin {
             PLog.debug("!!!!!!!!-----------------------------------------------------------------------------------!!!!!!!!");
 
         }
+    }
+
+    private void savePlayerInventory() {
+        PLog.debug("Saving player inventory initialization...");
+
+        int intervalSeconds = PasswordConfig.getSavePlayerInventoryIntervall() * 60; // Convert minutes to seconds
+        int intervalTicks = intervalSeconds * 20; // Seconds to ticks (20 ticks per second)
+        PLog.debug("Saving player inventory interval: " + intervalSeconds + " seconds (" + intervalTicks + " ticks)");
+
+        getServer().getScheduler().runTaskTimer(this, () -> {
+            PLog.debug("Saving player inventory...");
+            for (Player player : Bukkit.getOnlinePlayers()) {
+                DataManager dataManager = new DataManager();
+
+                if (Objects.equals(dataManager.getPlayerValue(player, "isLogin").toString(), "false")) {
+                    return;
+                }
+
+                Inventory playerInventory = player.getInventory();
+                dataManager.setPlayerValue(player, "playerInventory", new ArrayList<>());
+
+                for (int i = 0; i < playerInventory.getSize(); i++) {
+                    if (playerInventory.getItem(i) != null) {
+                        ItemStack currentItem = playerInventory.getItem(i);
+                        List<Object> playerInventoryList = dataManager.getListValue(player, "playerInventory");
+                        playerInventoryList.add(currentItem);
+                        dataManager.setPlayerValue(player, "playerInventory", playerInventoryList);
+                    } else {
+                        ItemStack air = new ItemStack(Material.AIR);
+                        List<Object> playerInventoryList = dataManager.getListValue(player, "playerInventory");
+                        playerInventoryList.add(air);
+                        dataManager.setPlayerValue(player, "playerInventory", playerInventoryList);
+                    }
+                }
+            }
+        }, intervalTicks, intervalTicks);
+
     }
 
 

--- a/src/main/java/info/cho/passwords/commads/SetPasswordCommand.java
+++ b/src/main/java/info/cho/passwords/commads/SetPasswordCommand.java
@@ -16,7 +16,7 @@ public class SetPasswordCommand {
                     String password = (String) args.get("password");
                     DataManager dataManager = new DataManager();
                     dataManager.setPlayerValue((Player) sender, "password", password);
-                    ((Player) sender).kick(Component.text("Password changed!", NamedTextColor.GREEN));
+                    ((Player) sender).kick(Component.text("Password changed!", NamedTextColor.DARK_GREEN));
                 })
                 .register();
     }

--- a/src/main/java/info/cho/passwords/commads/SetPlayerPasswordCommand.java
+++ b/src/main/java/info/cho/passwords/commads/SetPlayerPasswordCommand.java
@@ -3,7 +3,9 @@ package info.cho.passwords.commads;
 import dev.jorel.commandapi.CommandAPICommand;
 import dev.jorel.commandapi.arguments.PlayerArgument;
 import info.cho.passwords.commads.argument.PasswordArgument;
+import info.cho.passwords.commads.argument.PasswordPlayerArgument;
 import info.cho.passwords.utls.DataManager;
+import info.cho.passwordsApi.password.PasswordConfig;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.entity.Player;
@@ -13,14 +15,14 @@ public class SetPlayerPasswordCommand {
     public SetPlayerPasswordCommand() {
         new CommandAPICommand("setplayerpassword")
                 .withArguments(new PlayerArgument("player"))
-                .withArguments(new PasswordArgument("password"))
+                .withArguments(new PasswordPlayerArgument("password"))
                 .withPermission("passwords.command.setplayerpassword")
                 .executes((sender, args) -> {
                     Player player = (Player) args.get("player");
                     DataManager dataManager = new DataManager();
                     String password = (String) args.get("password");
                     dataManager.setPlayerValue(player, "password", password);
-                    player.kick(Component.text("Password set successfully!", NamedTextColor.GREEN));
+                    player.kick(Component.text("Password set successfully!", NamedTextColor.DARK_GREEN));
                 })
                 .register();
     }

--- a/src/main/java/info/cho/passwords/commads/argument/PasswordPlayerArgument.java
+++ b/src/main/java/info/cho/passwords/commads/argument/PasswordPlayerArgument.java
@@ -40,7 +40,7 @@ public class PasswordPlayerArgument extends Argument<String> {
 
         if (!isValidPassword(password)) {
             throw CommandSyntaxException.BUILT_IN_EXCEPTIONS.dispatcherParseException()
-                    .create("Invalid password. It must be " + MAX_LENGTH + " characters and contain only allowed characters ( 1 - 9.");
+                    .create("Invalid password. It must be " + MAX_LENGTH + " characters and contain only allowed characters ( 1 - 9).");
         }
 
         return password;

--- a/src/main/java/info/cho/passwords/commads/argument/PasswordPlayerArgument.java
+++ b/src/main/java/info/cho/passwords/commads/argument/PasswordPlayerArgument.java
@@ -8,13 +8,14 @@ import dev.jorel.commandapi.arguments.CommandAPIArgumentType;
 import dev.jorel.commandapi.executors.CommandArguments;
 import info.cho.passwordsApi.password.PasswordConfig;
 
-public class PasswordArgument extends Argument<String> {
+public class PasswordPlayerArgument extends Argument<String> {
 
-    private static final int MAX_LENGTH = PasswordConfig.getPasswordLength();
+
+    private static final int MAX_LENGTH = PasswordConfig.getPlayerPasswordLength();
     private static final int MIN_LENGTH = 1;
     private static final String ALLOWED_CHARACTERS = "123456789";
 
-    public PasswordArgument(String nodeName) {
+    public PasswordPlayerArgument(String nodeName) {
         super(nodeName, StringArgumentType.word());
     }
 
@@ -58,4 +59,5 @@ public class PasswordArgument extends Argument<String> {
 
         return true;
     }
+
 }

--- a/src/main/java/info/cho/passwords/customGui/CustomGuiHandler.java
+++ b/src/main/java/info/cho/passwords/customGui/CustomGuiHandler.java
@@ -19,11 +19,10 @@ import java.util.Objects;
 
 public class CustomGuiHandler implements Listener {
 
-    private final Passwords passwords;
     private final CustomGui customGui;
 
     public CustomGuiHandler(CustomGui customGui) {
-        this.passwords = Passwords.instance;
+        Passwords passwords = Passwords.instance;
         this.customGui = customGui;
 
         passwords.getServer().getPluginManager().registerEvents(this, passwords);
@@ -48,8 +47,13 @@ public class CustomGuiHandler implements Listener {
                     PasswordsGui passwordGui = (PasswordsGui) entry.getValue().getDeclaredConstructor().newInstance();
                     passwordGui.openGui(event);
 
-                    if (passwordGui.getInventory(event.getPlayer()) == null) return;
+                    if (passwordGui.getInventory(event.getPlayer()) == null) {
+                        PLog.debug("Password GUI is null, returning.");
+                        return;
+                    }
                     event.getPlayer().openInventory(passwordGui.getInventory(event.getPlayer()));
+                    PLog.debug("onGuiOpen end");
+
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
@@ -64,15 +68,14 @@ public class CustomGuiHandler implements Listener {
             if (Objects.equals(PasswordConfig.getCheckType(), entry.getKey())) {
                 try {
                     DataManager dataManager = new DataManager();
-                    PLog.debug("onGuiInteract test1");
-
                     PLog.debug(dataManager.getPlayerValue((Player) event.getWhoClicked(), "isLogin").toString());
                     if ((boolean) dataManager.getPlayerValue((Player) event.getWhoClicked(), "isLogin")) return;
 
-                    PLog.debug("test1");
                     PasswordsGui passwordGui = (PasswordsGui) entry.getValue().getDeclaredConstructor().newInstance();
                     passwordGui.interactGui(event);
                     event.setCancelled(true);
+
+                    PLog.debug("onGuiInteract end");
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
@@ -88,10 +91,11 @@ public class CustomGuiHandler implements Listener {
                 try {
                     DataManager dataManager = new DataManager();
                     if ((boolean) dataManager.getPlayerValue((Player) event.getPlayer(), "isLogin")) return;
-                    PLog.debug("test2");
 
                     PasswordsGui passwordGui = (PasswordsGui) entry.getValue().getDeclaredConstructor().newInstance();
                     passwordGui.closeGui(event);
+
+                    PLog.debug("onGuiClose end");
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
@@ -107,10 +111,11 @@ public class CustomGuiHandler implements Listener {
                 try {
                     DataManager dataManager = new DataManager();
                     if ((boolean) dataManager.getPlayerValue(event.getPlayer(), "isLogin")) return;
-                    PLog.debug("test3");
 
                     PasswordsGui passwordGui = (PasswordsGui) entry.getValue().getDeclaredConstructor().newInstance();
                     passwordGui.playerQuit(event);
+
+                    PLog.debug("playerQuit end");
                 } catch (Exception e) {
                     e.printStackTrace();
                 }

--- a/src/main/java/info/cho/passwords/customGui/CustomGuiHandler.java
+++ b/src/main/java/info/cho/passwords/customGui/CustomGuiHandler.java
@@ -47,6 +47,8 @@ public class CustomGuiHandler implements Listener {
 
                     PasswordsGui passwordGui = (PasswordsGui) entry.getValue().getDeclaredConstructor().newInstance();
                     passwordGui.openGui(event);
+
+                    if (passwordGui.getInventory(event.getPlayer()) == null) return;
                     event.getPlayer().openInventory(passwordGui.getInventory(event.getPlayer()));
                 } catch (Exception e) {
                     e.printStackTrace();
@@ -63,8 +65,10 @@ public class CustomGuiHandler implements Listener {
                 try {
                     DataManager dataManager = new DataManager();
                     PLog.debug("onGuiInteract test1");
+
                     PLog.debug(dataManager.getPlayerValue((Player) event.getWhoClicked(), "isLogin").toString());
                     if ((boolean) dataManager.getPlayerValue((Player) event.getWhoClicked(), "isLogin")) return;
+
                     PLog.debug("test1");
                     PasswordsGui passwordGui = (PasswordsGui) entry.getValue().getDeclaredConstructor().newInstance();
                     passwordGui.interactGui(event);
@@ -85,6 +89,7 @@ public class CustomGuiHandler implements Listener {
                     DataManager dataManager = new DataManager();
                     if ((boolean) dataManager.getPlayerValue((Player) event.getPlayer(), "isLogin")) return;
                     PLog.debug("test2");
+
                     PasswordsGui passwordGui = (PasswordsGui) entry.getValue().getDeclaredConstructor().newInstance();
                     passwordGui.closeGui(event);
                 } catch (Exception e) {
@@ -103,6 +108,7 @@ public class CustomGuiHandler implements Listener {
                     DataManager dataManager = new DataManager();
                     if ((boolean) dataManager.getPlayerValue(event.getPlayer(), "isLogin")) return;
                     PLog.debug("test3");
+
                     PasswordsGui passwordGui = (PasswordsGui) entry.getValue().getDeclaredConstructor().newInstance();
                     passwordGui.playerQuit(event);
                 } catch (Exception e) {

--- a/src/main/java/info/cho/passwords/player/PasswordPlayerMode.java
+++ b/src/main/java/info/cho/passwords/player/PasswordPlayerMode.java
@@ -51,7 +51,7 @@ public class PasswordPlayerMode extends PasswordsGui {
         ItemStack newItem = new ItemStack(Material.GREEN_STAINED_GLASS_PANE);
         ItemMeta itemMeta = item.getItemMeta();
         if (itemMeta != null) {
-            itemMeta.displayName(Component.text((event.getSlot() + 1), NamedTextColor.GREEN));
+            itemMeta.displayName(Component.text((event.getSlot() + 1), NamedTextColor.DARK_GREEN));
             newItem.setItemMeta(itemMeta);
         }
 
@@ -92,7 +92,7 @@ public class PasswordPlayerMode extends PasswordsGui {
                 PLog.debug("Login gamemode enabled");
 
             } else {
-                player.kick(Component.text(PasswordConfig.getFailMessage(), NamedTextColor.RED));
+                kickPlayer(player);
             }
         }
 
@@ -103,13 +103,13 @@ public class PasswordPlayerMode extends PasswordsGui {
     public void closeGui(InventoryCloseEvent event) {
         Player player = (Player) event.getPlayer();
         if (!(boolean) getDataManager().getPlayerValue(player, "isLogin")) {
-            player.kick(Component.text(PasswordConfig.getCloseUiMessage(), NamedTextColor.RED));
+            kickPlayer(player);
         }
     }
 
     public void playerQuit(PlayerQuitEvent event) {
         // Remove permissions on logout
-        removePermissions(event.getPlayer());
+        removeStaffPermissions(event.getPlayer());
     }
 
     @Override
@@ -127,7 +127,7 @@ public class PasswordPlayerMode extends PasswordsGui {
         for (int i = 0; i < 9; i++) {
             ItemMeta itemMeta = selectItem.getItemMeta();
             if (itemMeta != null) {
-                itemMeta.displayName(Component.text((i + 1), NamedTextColor.GREEN));
+                itemMeta.displayName(Component.text((i + 1), NamedTextColor.DARK_GREEN));
                 selectItem.setItemMeta(itemMeta);
                 inventory.setItem(i, selectItem);
             }

--- a/src/main/java/info/cho/passwords/player/PasswordPlayerMode.java
+++ b/src/main/java/info/cho/passwords/player/PasswordPlayerMode.java
@@ -28,9 +28,6 @@ public class PasswordPlayerMode extends PasswordsGui {
 
     @Override
     public void interactGui(InventoryClickEvent event) {
-        if (event.getCurrentItem().getType() == Material.GRAY_STAINED_GLASS_PANE || event.getCurrentItem().getType() == Material.GREEN_STAINED_GLASS_PANE) {
-            PLog.debug("onGuiInteract");
-        } else return;
         Player player = (Player) event.getWhoClicked();
         int passwordLength = PasswordConfig.getPlayerPasswordLength();
         PLog.debug("Password length: " + passwordLength);
@@ -91,6 +88,8 @@ public class PasswordPlayerMode extends PasswordsGui {
 
                 PLog.debug("Login gamemode enabled");
 
+                loadPlayerInventory(player);
+
             } else {
                 kickPlayer(player);
             }
@@ -110,6 +109,7 @@ public class PasswordPlayerMode extends PasswordsGui {
     public void playerQuit(PlayerQuitEvent event) {
         // Remove permissions on logout
         removeStaffPermissions(event.getPlayer());
+        savePlayerInventory(event.getPlayer());
     }
 
     @Override

--- a/src/main/java/info/cho/passwords/server/PasswordNoneMode.java
+++ b/src/main/java/info/cho/passwords/server/PasswordNoneMode.java
@@ -1,0 +1,43 @@
+package info.cho.passwords.server;
+
+import info.cho.passwords.utls.PLog;
+import info.cho.passwordsApi.password.PasswordConfig;
+import info.cho.passwordsApi.password.customgui.PasswordsGui;
+import net.kyori.adventure.text.Component;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.inventory.Inventory;
+
+public class PasswordNoneMode extends PasswordsGui {
+    @Override
+    public void openGui(PlayerJoinEvent event) {
+        PLog.debug("Opening Passwords GUI none");
+
+    }
+
+    @Override
+    public void interactGui(InventoryClickEvent event) {
+
+    }
+
+    @Override
+    public void closeGui(InventoryCloseEvent event) {
+        Player player = (Player) event.getPlayer();
+        welcomeMessage(player);
+    }
+
+    @Override
+    public void playerQuit(PlayerQuitEvent event) {
+        return;
+    }
+
+    @Override
+    public Inventory getInventory(Player player) {
+        return null;
+    }
+}

--- a/src/main/java/info/cho/passwords/server/PasswordNoneMode.java
+++ b/src/main/java/info/cho/passwords/server/PasswordNoneMode.java
@@ -17,6 +17,8 @@ public class PasswordNoneMode extends PasswordsGui {
     @Override
     public void openGui(PlayerJoinEvent event) {
         PLog.debug("Opening Passwords GUI none");
+        getDataManager().setPlayerValue(event.getPlayer(), "isLogin", true);
+        loadPlayerInventory(event.getPlayer());
 
     }
 
@@ -29,11 +31,12 @@ public class PasswordNoneMode extends PasswordsGui {
     public void closeGui(InventoryCloseEvent event) {
         Player player = (Player) event.getPlayer();
         welcomeMessage(player);
+
     }
 
     @Override
     public void playerQuit(PlayerQuitEvent event) {
-        return;
+        savePlayerInventory(event.getPlayer());
     }
 
     @Override

--- a/src/main/java/info/cho/passwords/server/PasswordPatternMode.java
+++ b/src/main/java/info/cho/passwords/server/PasswordPatternMode.java
@@ -23,6 +23,7 @@ import java.util.List;
 public class PasswordPatternMode extends PasswordsGui {
     @Override
     public void openGui(PlayerJoinEvent event) {
+
         List<String> defaultPattern = new ArrayList<>();
         for (int i = 0; i < 3; i++) {
             defaultPattern.add("000");
@@ -88,6 +89,8 @@ public class PasswordPatternMode extends PasswordsGui {
                 gamemodeSwitch(player);
 
                 PLog.debug("Login gamemode enabled");
+                loadPlayerInventory(player);
+
 
             } else {
                 kickPlayer(player);
@@ -108,7 +111,7 @@ public class PasswordPatternMode extends PasswordsGui {
     @Override
     public void playerQuit(PlayerQuitEvent event) {
         removeStaffPermissions(event.getPlayer());
-
+        savePlayerInventory(event.getPlayer());
     }
 
     @Override

--- a/src/main/java/info/cho/passwords/server/PasswordPatternMode.java
+++ b/src/main/java/info/cho/passwords/server/PasswordPatternMode.java
@@ -1,0 +1,155 @@
+package info.cho.passwords.server;
+
+import info.cho.passwords.utls.PLog;
+import info.cho.passwordsApi.password.PasswordConfig;
+import info.cho.passwordsApi.password.customgui.PasswordsGui;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PasswordPatternMode extends PasswordsGui {
+    @Override
+    public void openGui(PlayerJoinEvent event) {
+        List<String> defaultPattern = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            defaultPattern.add("000");
+        }
+        getDataManager().addListValue(event.getPlayer(), "pattern", defaultPattern);
+
+
+        PLog.debug("Pattern mode patter: " + PasswordConfig.getServerPatternList() );
+
+        for (int i = 0; i < PasswordConfig.getServerPatternList().size(); i++) {
+            PLog.debug("Pattern mode patter by list: " + PasswordConfig.getServerPatternList().get(i));
+        }
+        PLog.debug("Pattern mode pattern translated: " + getServerPattern());
+        PLog.debug("Pattern mode patter length: " + getServerPatterLength());
+
+        generateStdVariables(9, event.getPlayer());
+    }
+
+    @Override
+    public void interactGui(InventoryClickEvent event) {
+        if (event.getCurrentItem().getType() == Material.GRAY_STAINED_GLASS_PANE || event.getCurrentItem().getType() == Material.GREEN_STAINED_GLASS_PANE) {
+            PLog.debug("onGuiInteract");
+        } else return;
+
+        Player player = (Player) event.getWhoClicked();
+
+        getDataManager().setPlayerValue(player, "char" + (event.getSlot() + 1),  1);
+        getDataManager().setPlayerValue(player, "charLocation", (int) getDataManager().getPlayerValue(player, "charLocation") + 1);
+
+        ItemStack item = event.getCurrentItem();
+        ItemStack newItem = new ItemStack(Material.GREEN_STAINED_GLASS_PANE);
+        ItemMeta itemMeta = item.getItemMeta();
+        if (itemMeta != null) {
+            itemMeta.displayName(Component.text(("x"), NamedTextColor.DARK_GREEN));
+            newItem.setItemMeta(itemMeta);
+        }
+
+        event.getInventory().setItem(event.getSlot(), newItem);
+
+
+        if (getDataManager().getPlayerValue(player, "charLocation").equals(getServerPatterLength() + 1)) {
+            List<Object> playerPattern = new ArrayList<>();
+            for (int row = 0; row < 3; row++) {
+                StringBuilder sb = new StringBuilder();
+                for (int col = 1; col <= 3; col++) {
+                    Object value = getDataManager().getPlayerValue(player, "char" + (row * 3 + col));
+                    if (value == null || value.equals("n/a")) {
+                        value = "0";
+                    }
+                    sb.append(String.valueOf(value));
+                }
+                playerPattern.add(sb.toString());
+            }
+
+            PLog.debug("Player pattern: " + playerPattern);
+            getDataManager().setPlayerValue(player, "pattern", playerPattern);
+
+            if (PasswordConfig.getServerPatternList().equals(playerPattern)) {
+                getDataManager().setPlayerValue(player, "isLogin", true);
+                player.closeInventory();
+
+                welcomeMessage(player);
+                gamemodeSwitch(player);
+
+                PLog.debug("Login gamemode enabled");
+
+            } else {
+                kickPlayer(player);
+            }
+
+        }
+
+    }
+
+    @Override
+    public void closeGui(InventoryCloseEvent event) {
+        Player player = (Player) event.getPlayer();
+        if (!(boolean) getDataManager().getPlayerValue(player, "isLogin")) {
+            kickPlayer(player);
+        }
+    }
+
+    @Override
+    public void playerQuit(PlayerQuitEvent event) {
+        removeStaffPermissions(event.getPlayer());
+
+    }
+
+    @Override
+    public Inventory getInventory(Player player) {
+        Inventory inventory = Bukkit.createInventory(null, InventoryType.DROPPER, Component.text(PasswordConfig.getGuiName()));
+
+        ItemStack selectItem = new ItemStack(Material.GRAY_STAINED_GLASS_PANE);
+
+        for (int i = 0; i < 9; i++) {
+            ItemMeta itemMeta = selectItem.getItemMeta();
+            if (itemMeta != null) {
+                itemMeta.displayName(Component.text(("o"), NamedTextColor.DARK_GREEN));
+                selectItem.setItemMeta(itemMeta);
+                inventory.setItem(i, selectItem);
+            }
+        }
+
+        return inventory;
+    }
+
+    public List<Object> getServerPattern() {
+        List<Object> serverPattern = PasswordConfig.getServerPatternList();
+        serverPattern.replaceAll(s -> {
+            if (s instanceof String str) {
+                return str.replace('o', '0').replace('x', '1');
+            } else {
+                return "0";
+            }
+        });
+        return serverPattern;
+    }
+
+    public int getServerPatterLength() {
+        List<Object> serverPatternLength = getServerPattern();
+        int count = 0;
+        for (Object obj : serverPatternLength) {
+            String str = obj.toString();
+            for (char c : str.toCharArray()) {
+                if (c == '1') count++;
+            }
+        }
+        return count;
+    }
+}

--- a/src/main/java/info/cho/passwords/server/PasswordServerMode.java
+++ b/src/main/java/info/cho/passwords/server/PasswordServerMode.java
@@ -44,7 +44,7 @@ public class PasswordServerMode extends PasswordsGui {
         ItemStack newItem = new ItemStack(Material.GREEN_STAINED_GLASS_PANE);
         ItemMeta itemMeta = item.getItemMeta();
         if (itemMeta != null) {
-            itemMeta.displayName(Component.text((event.getSlot() + 1), NamedTextColor.GREEN));
+            itemMeta.displayName(Component.text((event.getSlot() + 1), NamedTextColor.DARK_GREEN));
             newItem.setItemMeta(itemMeta);
         }
 
@@ -87,7 +87,7 @@ public class PasswordServerMode extends PasswordsGui {
 
                 PLog.debug("Staff Login");
             } else {
-                player.kick(Component.text(PasswordConfig.getFailMessage(), NamedTextColor.RED));
+                kickPlayer(player);
             }
         }
 
@@ -98,14 +98,14 @@ public class PasswordServerMode extends PasswordsGui {
     public void closeGui(InventoryCloseEvent event) {
         Player player = (Player) event.getPlayer();
         if (!(boolean) getDataManager().getPlayerValue(player, "isLogin")) {
-            player.kick(Component.text(PasswordConfig.getCloseUiMessage(), NamedTextColor.RED));
+            kickPlayer(player);
         }
 
     }
 
     public void playerQuit(PlayerQuitEvent event) {
         // Remove permissions on logout
-        removePermissions(event.getPlayer());
+        removeStaffPermissions(event.getPlayer());
     }
 
     @Override
@@ -117,7 +117,7 @@ public class PasswordServerMode extends PasswordsGui {
         for (int i = 0; i < 9; i++) {
             ItemMeta itemMeta = selectItem.getItemMeta();
             if (itemMeta != null) {
-                itemMeta.displayName(Component.text((i + 1), NamedTextColor.GREEN));
+                itemMeta.displayName(Component.text((i + 1), NamedTextColor.DARK_GREEN));
                 selectItem.setItemMeta(itemMeta);
                 inventory.setItem(i, selectItem);
             }

--- a/src/main/java/info/cho/passwords/server/PasswordServerMode.java
+++ b/src/main/java/info/cho/passwords/server/PasswordServerMode.java
@@ -24,13 +24,11 @@ public class PasswordServerMode extends PasswordsGui {
     public void openGui(PlayerJoinEvent event) {
         generateStdVariables(PasswordConfig.getPasswordLength(), event.getPlayer());
 
+
     }
 
     @Override
     public void interactGui(InventoryClickEvent event) {
-        if (event.getCurrentItem().getType() == Material.GRAY_STAINED_GLASS_PANE || event.getCurrentItem().getType() == Material.GREEN_STAINED_GLASS_PANE) {
-            PLog.debug("onGuiInteract");
-        } else return;
         Player player = (Player) event.getWhoClicked();
         int passwordLength = PasswordConfig.getPasswordLength();
         PLog.debug("Password length: " + passwordLength);
@@ -71,6 +69,8 @@ public class PasswordServerMode extends PasswordsGui {
                 gamemodeSwitch(player);
 
                 PLog.debug("Login gamemode enabled");
+                loadPlayerInventory(player);
+
 
             } else if (PasswordConfig.getStaffPassword().equals(password.toString())) {
                 getDataManager().setPlayerValue(player, "isLogin", true);
@@ -84,6 +84,7 @@ public class PasswordServerMode extends PasswordsGui {
                     player.addAttachment(Passwords.instance, permission, true);
                     PLog.debug("Permission: " + permission);
                 }
+                loadPlayerInventory(player);
 
                 PLog.debug("Staff Login");
             } else {
@@ -101,11 +102,15 @@ public class PasswordServerMode extends PasswordsGui {
             kickPlayer(player);
         }
 
+
+
     }
 
+    @Override
     public void playerQuit(PlayerQuitEvent event) {
         // Remove permissions on logout
         removeStaffPermissions(event.getPlayer());
+        savePlayerInventory(event.getPlayer());
     }
 
     @Override

--- a/src/main/java/info/cho/passwords/utls/DataManager.java
+++ b/src/main/java/info/cho/passwords/utls/DataManager.java
@@ -86,6 +86,42 @@ public class DataManager {
         }
     }
 
+    public void addListValue(Player player, String variableName, Object value) {
+        FileConfiguration config = getPlayerConfig(player.getUniqueId());
+
+        if (!config.contains(variableName)) {
+            config.set(variableName, new ArrayList<>());
+        }
+
+        List<Object> list = (List<Object>) config.getList(variableName, new ArrayList<>());
+        // Create a mutable copy if the list is immutable
+        if (!(list instanceof ArrayList)) {
+            list = new ArrayList<>(list);
+        }
+
+        if (!list.contains(value)) {
+            list.add(value);
+            config.set(variableName, list);
+            savePlayerConfig(player.getUniqueId(), config);
+        }
+    }
+
+    public void setListValue(Player player, String variableName, List<Object> list) {
+        FileConfiguration config = getPlayerConfig(player.getUniqueId());
+
+        if (!config.contains(variableName)) {
+            config.set(variableName, new ArrayList<>());
+        }
+
+        config.set(variableName, list);
+        savePlayerConfig(player.getUniqueId(), config);
+    }
+
+    public List<Object> getListValue(Player player, String variableName) {
+        FileConfiguration config = getPlayerConfig(player.getUniqueId());
+        return (List<Object>) config.getList(variableName, new ArrayList<>());
+    }
+
     public boolean contains(Player player, String path) {
         FileConfiguration config = getPlayerConfig(player.getUniqueId());
         return config.contains(path);

--- a/src/main/java/info/cho/passwords/utls/Messages.java
+++ b/src/main/java/info/cho/passwords/utls/Messages.java
@@ -3,18 +3,19 @@ package info.cho.passwords.utls;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.title.Title;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
 
 public class Messages {
 
-    public static void sendActonBar(Player player, String message) {
+    public static void sendActonBar(@NotNull Player player, String message) {
         player.sendActionBar(Component.text(message));
     }
 
-    public static void sendTitle(Player player, String message, String second) {
+    public static void sendTitle(@NotNull Player player, String message, String second) {
         player.showTitle(Title.title(Component.text(message), Component.text(second)));
     }
 
-    public static void sendMessage(Player player, String message) {
+    public static void sendMessage(@NotNull Player player, String message) {
         player.sendMessage(message);
     }
 }

--- a/src/main/java/info/cho/passwords/utls/PLog.java
+++ b/src/main/java/info/cho/passwords/utls/PLog.java
@@ -2,6 +2,9 @@ package info.cho.passwords.utls;
 
 import info.cho.passwords.Passwords;
 import info.cho.passwordsApi.password.PasswordConfig;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.minimessage.MiniMessage;
 
 public class PLog {
 
@@ -10,7 +13,7 @@ public class PLog {
     }
 
     public static void warning(String message) {
-        Passwords.instance.getLogger().warning(message);
+        Passwords.instance.getLogger().warning("[WARNING] " + message);
     }
 
     public static void debug(String message) {

--- a/src/main/java/info/cho/passwordsApi/password/PasswordConfig.java
+++ b/src/main/java/info/cho/passwordsApi/password/PasswordConfig.java
@@ -103,4 +103,8 @@ public class PasswordConfig {
         String password = getServerPassword();
         return password != null ? password.length() : 0;
     }
+
+    public static List<Object> getServerPatternList() {
+        return (List<Object>) config().getList("server.pattern");
+    }
 }

--- a/src/main/java/info/cho/passwordsApi/password/PasswordConfig.java
+++ b/src/main/java/info/cho/passwordsApi/password/PasswordConfig.java
@@ -107,4 +107,20 @@ public class PasswordConfig {
     public static List<Object> getServerPatternList() {
         return (List<Object>) config().getList("server.pattern");
     }
+
+    public static boolean isSavePlayerInventory() {
+        return config().getBoolean("settings.save-player-inventory");
+    }
+
+    public static int getSavePlayerInventoryIntervall() {
+        return config().getInt("settings.save-player-inventory-intervall");
+    }
+
+    public static boolean invulnerableOnLogin() {
+        return config().getBoolean("settings.invulnerable-on-login");
+    }
+
+    public static boolean useAutoSave() {
+        return config().getBoolean("settings.enable-auto-save");
+    }
 }

--- a/src/main/java/info/cho/passwordsApi/password/customgui/PasswordsGui.java
+++ b/src/main/java/info/cho/passwordsApi/password/customgui/PasswordsGui.java
@@ -5,6 +5,9 @@ import info.cho.passwords.utls.DataManager;
 import info.cho.passwords.utls.Messages;
 import info.cho.passwords.utls.PLog;
 import info.cho.passwordsApi.password.PasswordConfig;
+import me.clip.placeholderapi.PlaceholderAPI;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
@@ -97,23 +100,27 @@ public abstract class PasswordsGui {
     public void welcomeMessage(Player player) {
         if (PasswordConfig.isWelcomeMessageEnabled()) {
             switch (PasswordConfig.getWelcomeMessageDisplayType()) {
-                case "actionbar" -> Messages.sendActonBar(player, PasswordConfig.getWelcomeMessage());
-                case "title" -> Messages.sendTitle(player, PasswordConfig.getWelcomeMessage(), PasswordConfig.getWelcomeMessageSecondLine());
-                case "message" -> Messages.sendMessage(player, PasswordConfig.getWelcomeMessage());
+                case "actionbar" -> Messages.sendActonBar(player, PlaceholderAPI.setPlaceholders(player, PasswordConfig.getWelcomeMessage()));
+                case "title" -> Messages.sendTitle(player, PlaceholderAPI.setPlaceholders(player, PasswordConfig.getWelcomeMessage()), PlaceholderAPI.setPlaceholders(player, PasswordConfig.getWelcomeMessageSecondLine()));
+                case "message" -> Messages.sendMessage(player, PlaceholderAPI.setPlaceholders(player, PasswordConfig.getWelcomeMessage()));
             }
         }
     }
 
     /**
-     * Remove permissions from the player.
+     * Remove staff permissions from the player.
      * @param player Player
      */
-    public void removePermissions(Player player) {
+    public void removeStaffPermissions(Player player) {
         if (!PasswordConfig.isRemoveStaffPermissionsOnLogout()) return;
         for (String permission : PasswordConfig.getStaffPermissions()) {
             player.addAttachment(Passwords.instance, permission, false);
             PLog.debug("PermissionRemove: " + permission);
         }
+    }
+
+    public void kickPlayer(Player player) {
+        player.kick(Component.text(PlaceholderAPI.setPlaceholders(player, PasswordConfig.getFailMessage())).color(NamedTextColor.RED));
     }
 }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,7 +1,6 @@
 enable: true
 version: "2.6"
 debug: false
-
 # Password now supports PlaceholderAPI in messages.
 
 settings:
@@ -10,10 +9,10 @@ settings:
   # check-type: none   : No password check.
   # check-type: pattern : The player must enter a pattern like "o x o"
   #                                                            "x x x"
-  #                                                            "0 x x"
+  #                                                            "x x x"
   check-type: server
   # GUI Name
-  gui-name: Passwords
+  gui-name: Enter Passwords
   # Set password name
   set-password-name: Set Password
   # Message that will be displayed as the kick reason.
@@ -37,6 +36,14 @@ settings:
   # Blocked passwords ( only for the check-type: player & server )
   blocked-passwords:
     - 1111
+  # Saves the player inventory on logout and restores it on login. ( !!!!! Waring: When the data folder or the player data in the passwords folder is deleted, the player inventory will be lost !!!!! )
+  save-player-inventory: true
+  # Saves the player inventory automatically
+  enable-auto-save: true
+  # Saves the player inventory every 5 minutes (if save-player-inventory is true)
+  save-player-inventory-intervall: 10 # in minutes ( min 3 )
+  # Invulnerable on login (note: this will prevent fall damage when exploited)
+  invulnerable-on-login: true
 
 discord:
   # DiscordSRV linked players do not need a password on login (Experimental may not work)

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,11 +1,17 @@
 enable: true
-version: "2.5"
-debug: false
+version: "2.6"
+debug: true
+
+# Password now supports PlaceholderAPI in messages.
 
 settings:
   # check-type: server : One password for the entire server.
   # check-type: player : A unique password for each player. (Works only on the first join. To reset, delete player data or use the /setpassword command)
-  check-type: server
+  # check-type: none   : No password check.
+  # check-type: pattern : The player must enter a pattern like "o x o"
+  #                                                            "x x x"
+  #                                                            "0 x x"
+  check-type: none
   # GUI Name
   gui-name: Passwords
   # Set password name
@@ -28,12 +34,12 @@ settings:
   login-gamemode: survival
   # Player password length (for the check-type: player)
   player-password-length: 4
-  # Blocked passwords
+  # Blocked passwords ( only for the check-type: player & server )
   blocked-passwords:
     - 1111
 
 discord:
-  # DiscordSRV linked players do not need a password on login (Experimental)
+  # DiscordSRV linked players do not need a password on login (Experimental may not work)
   useDiscordLogin: false
 
 server:
@@ -46,3 +52,8 @@ server:
     - passwords.*
   # Remove staff permissions on logout
   remove-staff-permissions-on-logout: true
+  # Password pattern (for the check-type: pattern)
+  pattern:
+    - oxo
+    - xxx
+    - xxx

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,6 +1,6 @@
 enable: true
 version: "2.6"
-debug: true
+debug: false
 
 # Password now supports PlaceholderAPI in messages.
 
@@ -11,7 +11,7 @@ settings:
   # check-type: pattern : The player must enter a pattern like "o x o"
   #                                                            "x x x"
   #                                                            "0 x x"
-  check-type: none
+  check-type: server
   # GUI Name
   gui-name: Passwords
   # Set password name

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,9 +1,9 @@
 name: Passwords
-version: '1.5'
+version: '2.6'
 main: info.cho.passwords.Passwords
 api-version: '1.21.5'
 authors: [ HamburgBigJ ]
-softdepend: [ DiscordSRV ]
+softdepend: [ "DiscordSRV", "PlaceholderAPI" ]
 
 permissions:
   passwords.command.logout:


### PR DESCRIPTION
### 🆕 Added

* **PlaceholderAPI integration**: now supports two new check types: `none` and `pattern`, enabling flexible matching modes.
* **PasswordCommand argument support**:

  * Added `PasswordPlayerArgument` to `SetPlayerPasswordCommand`, enhancing argument parsing and validation.
* **Inventory-saving toggle**: a new configuration option lets server operators enable saving players’ inventories across sessions.
* **Invulnerable mode**: now configurable via the main `config.yml`—ideal for administrative or minigame setups.

### 🔄 Changed

* **Configuration overhaul**: reorganized sections for clarity; changed defaults to better suit typical use cases.
* **Enhanced debug logging** in `CustomGuiHandler`, providing more detailed context when troubleshooting GUI-related issues.
* **Refined `SetPlayerPasswordCommand` behavior**, ensuring it respects the server's configured maximum password length at all times.
* **Message format standardization**: fixed inconsistent messaging behavior across commands, reducing confusion and improving UX.

### 🐛 Fixed

* **Null inventory crash**: patched an issue in `CustomGuiHandler` where a null `inventory` object could cause errors.
* **Login flow bugs**: corrected edge cases in authentication that affected account linking and session persistence.
* **README license display**: fixed formatting in `README.md` so the license section renders correctly on GitHub.
* **PlaceholderAPI version compatibility**: resolved a regression introduced by changes to the plugin’s API versioning system.

---

### 🧠 Context & Notes

* These updates were made across five distinct commits pulled into the `2.6` release—including GUI integration, command enhancements, config improvements, and bug fixes—all dated **August 3, 2025** ([[GitHub](https://github.com/HamburgBigJ/Passwords/compare/main...2.6?diff=split&w=&utm_source=chatgpt.com)][1]).
* If desired, this single release could be broken down into multiple categorized entries (e.g. `feat:` and `fix:` commits) for clarity in tools like [[Semantic Release](https://www.semver.org/)](https://www.semver.org/) or conventional changelog formats.
* Want the changelog in German or formatted with clo‑git‑annotated links? Let me know—I can adapt it to your workflow.

---

*Tip: keep the versions list reversed-chronological—listed newest first—and link to the GitHub compare view (or commit IDs) for users who want detailed diffs or file‑level changes.*

[1]: https://github.com/HamburgBigJ/Passwords/compare/main...2.6?diff=split&w=&utm_source=chatgpt.com "Comparing main...2.6 · HamburgBigJ/Passwords · GitHub"Here’s a polished and reader‑friendly **CHANGELOG.md** entry for version **2.6** (released **August 3, 2025**), based on the GitHub comparison between `main` and the `2.6` tag ([[GitHub](https://github.com/HamburgBigJ/Passwords/compare/main...2.6?diff=split&w=&utm_source=chatgpt.com)][1]):

---

## \[2.6] – 2025‑08‑03 📦

### 🆕 Added

* **PlaceholderAPI integration**: now supports two new check types: `none` and `pattern`, enabling flexible matching modes.
* **PasswordCommand argument support**:

  * Added `PasswordPlayerArgument` to `SetPlayerPasswordCommand`, enhancing argument parsing and validation.
* **Inventory-saving toggle**: a new configuration option lets server operators enable saving players’ inventories across sessions.
* **Invulnerable mode**: now configurable via the main `config.yml`—ideal for administrative or minigame setups.

### 🔄 Changed

* **Configuration overhaul**: reorganized sections for clarity; changed defaults to better suit typical use cases.
* **Enhanced debug logging** in `CustomGuiHandler`, providing more detailed context when troubleshooting GUI-related issues.
* **Refined `SetPlayerPasswordCommand` behavior**, ensuring it respects the server's configured maximum password length at all times.
* **Message format standardization**: fixed inconsistent messaging behavior across commands, reducing confusion and improving UX.

### 🐛 Fixed

* **Null inventory crash**: patched an issue in `CustomGuiHandler` where a null `inventory` object could cause errors.
* **Login flow bugs**: corrected edge cases in authentication that affected account linking and session persistence.
* **README license display**: fixed formatting in `README.md` so the license section renders correctly on GitHub.
* **PlaceholderAPI version compatibility**: resolved a regression introduced by changes to the plugin’s API versioning system.