### PR TITLE
Fix autosave login check

### DIFF
--- a/src/main/java/info/cho/passwords/Passwords.java
+++ b/src/main/java/info/cho/passwords/Passwords.java
@@ -123,8 +123,10 @@ public class Passwords extends JavaPlugin {
             for (Player player : Bukkit.getOnlinePlayers()) {
                 DataManager dataManager = new DataManager();
 
-                if (Objects.equals(dataManager.getPlayerValue(player, "isLogin").toString(), "false")) {
-                    return;
+                Object loginValue = dataManager.getPlayerValue(player, "isLogin");
+                boolean isLoggedIn = loginValue != null && Boolean.parseBoolean(loginValue.toString());
+                if (!isLoggedIn) {
+                    continue;
                 }
 
                 Inventory playerInventory = player.getInventory();


### PR DESCRIPTION
## Summary
- prevent the periodic inventory save task from exiting when a single player is not logged in
- guard against null login values when checking whether to save inventory data

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68d5b6f2ad8c832c817aef1bedb1d11d